### PR TITLE
installed a newer version of okta-react-bug-fix that now redirects to…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3460,6 +3460,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6277,6 +6286,12 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -8095,6 +8110,8 @@
           "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -10292,6 +10309,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -10686,9 +10709,9 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "okta-react-bug-fix": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/okta-react-bug-fix/-/okta-react-bug-fix-2.0.6.tgz",
-      "integrity": "sha512-K2eHEIf5xLX1vmIc9dmPg/7itcoIor4QXWUaMaqTFOi0IqmUXW1wMO2uNuGrdR6OH2HmNLjDHAIL4UoFbH8Agw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/okta-react-bug-fix/-/okta-react-bug-fix-2.0.7.tgz",
+      "integrity": "sha512-jeH1+2GIcwfmYeDATbcAMNr/YIAceP894xiBTxktfAGNK1H74Ae5Jr/Bpf8nZdiwW1MEPgjEewUlHC68hH9OAg==",
       "requires": {
         "@okta/configuration-validation": "^0.4.1",
         "@okta/okta-auth-js": "^2.11.2",
@@ -15145,6 +15168,8 @@
           "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -15925,6 +15950,8 @@
           "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/redux-logger": "^3.0.7",
     "@types/styled-components": "^5.0.1",
     "axios": "^0.19.2",
-    "okta-react-bug-fix": "^2.0.6",
+    "okta-react-bug-fix": "^2.0.7",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-google-login": "^5.1.2",


### PR DESCRIPTION
Because of the LoginCallback component that we are using from @okta-react has a bug that has been corrected but not published yet i went ahead and cloned the @okta-react repo and made the changes to fix the bug and renamed it to okta-react-bug-fix so that i could publish the package myself for our team to use in the front-end which is what we've been using this whole time. Well Also in the LoginCallback component from @okta-react is the code that tells okta where to redirect the user after login success. Its set up to default to the "/" route so i made changes to the package to redirect to "/dashboard" after login and republished. So in this PR i just installed that latest version that i package and should now redirect to dashboard after login.